### PR TITLE
Add simple React frontend for disease search

### DIFF
--- a/frontend/README_frontend.md
+++ b/frontend/README_frontend.md
@@ -1,0 +1,7 @@
+# Disease Search Frontend
+
+This directory contains a simple React-based user interface for searching diseases. The UI allows you to enter a disease name and returns the symptoms, diagnosis, and treatment for that disease based on a small built-in dataset.
+
+## Running
+
+Open `index.html` in a modern web browser. The page uses CDN links for React and Babel, so no additional build steps are required.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Disease Search</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="index.js"></script>
+</body>
+</html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,60 @@
+const diseases = [
+  {
+    name: 'Common Cold',
+    symptoms: ['Runny nose', 'Sneezing', 'Sore throat'],
+    diagnosis: 'Usually based on symptoms and physical examination.',
+    treatment: 'Rest, fluids, and over-the-counter medications.'
+  },
+  {
+    name: 'Diabetes',
+    symptoms: ['Increased thirst', 'Frequent urination', 'Fatigue'],
+    diagnosis: 'Blood sugar testing by a healthcare provider.',
+    treatment: 'Lifestyle changes, monitoring, and medication as prescribed.'
+  },
+  {
+    name: 'Influenza',
+    symptoms: ['Fever', 'Chills', 'Body aches'],
+    diagnosis: 'Rapid influenza diagnostic tests or clinical evaluation.',
+    treatment: 'Antiviral medication and supportive care.'
+  }
+];
+
+function App() {
+  const [query, setQuery] = React.useState('');
+  const [result, setResult] = React.useState(null);
+
+  const handleSearch = () => {
+    const found = diseases.find(d => d.name.toLowerCase() === query.trim().toLowerCase());
+    setResult(found ? found : { error: 'Disease not found' });
+  };
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Disease Lookup</h1>
+      <input
+        type="text"
+        placeholder="Enter disease name"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        style={{ padding: '8px', width: '250px' }}
+      />
+      <button onClick={handleSearch} style={{ marginLeft: '10px', padding: '8px' }}>
+        Search
+      </button>
+      {result && (
+        <div style={{ marginTop: '20px' }}>
+          <h2>{result.error ? result.error : result.name}</h2>
+          {!result.error && (
+            <ul>
+              <li><strong>Symptoms:</strong> {result.symptoms.join(', ')}</li>
+              <li><strong>Diagnosis:</strong> {result.diagnosis}</li>
+              <li><strong>Treatment:</strong> {result.treatment}</li>
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- create a `frontend` directory
- add React `index.html` that loads React via CDN
- implement `index.js` with a small disease dataset and search logic
- document how to run the frontend in `README_frontend.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861351a92b88330acb70840c836dec4