### PR TITLE
Add DSM clustering script and docs

### DIFF
--- a/Backend/cluster_dsm.py
+++ b/Backend/cluster_dsm.py
@@ -1,0 +1,60 @@
+import argparse
+import pandas as pd
+from sentence_transformers import SentenceTransformer
+import umap
+import matplotlib.pyplot as plt
+
+
+def load_texts(csv_path: str, text_column: str = "criteria_text"):
+    """Load the DSM criteria from a CSV file."""
+    df = pd.read_csv(csv_path)
+    if text_column not in df.columns:
+        raise ValueError(f"Column '{text_column}' not found in {csv_path}")
+    return df
+
+
+def embed_texts(texts, model_name="mental-roberta-base"):
+    """Embed texts using a SentenceTransformer model."""
+    model = SentenceTransformer(model_name)
+    return model.encode(texts, show_progress_bar=True)
+
+
+def run_umap(embeddings, neighbors=10, min_dist=0.05):
+    """Reduce embeddings to 2D using UMAP."""
+    reducer = umap.UMAP(n_neighbors=neighbors, min_dist=min_dist, metric="cosine")
+    return reducer.fit_transform(embeddings)
+
+
+def plot_embeddings(coords, labels, out_path=None):
+    """Plot the 2D coordinates with disorder labels."""
+    plt.figure(figsize=(10, 8))
+    plt.scatter(coords[:, 0], coords[:, 1], s=20)
+    for i, label in enumerate(labels):
+        plt.annotate(label, (coords[i, 0], coords[i, 1]), fontsize=8)
+    plt.title("UMAP projection of DSM diagnostic descriptions")
+    if out_path:
+        plt.savefig(out_path, bbox_inches="tight")
+    else:
+        plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Embed DSM text and plot UMAP clusters")
+    parser.add_argument("csv", help="Path to CSV with DSM criteria")
+    parser.add_argument("--text-column", default="criteria_text", help="Column containing criteria text")
+    parser.add_argument("--label-column", default="disorder_name", help="Column for disorder labels")
+    parser.add_argument("--model", default="mental-roberta-base", help="SentenceTransformer model")
+    parser.add_argument("--output", help="Path to save plot (optional)")
+    args = parser.parse_args()
+
+    df = load_texts(args.csv, args.text_column)
+    texts = df[args.text_column].tolist()
+    labels = df[args.label_column].tolist() if args.label_column in df.columns else ["" for _ in texts]
+
+    embeddings = embed_texts(texts, args.model)
+    coords = run_umap(embeddings)
+    plot_embeddings(coords, labels, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,1 +1,4 @@
-
+pandas
+sentence-transformers
+umap-learn
+matplotlib

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# DSM
-This is my attempt at using various embedding and clustering techniques on subsets of mental disorders in the DSM-5. The objective is to find clusters of diseases based on clinical presenatations and to explore the different disease clusterings. Future work will aim to find treatment recommendations based on cluster membership
+# DSM Clustering Example
+
+This repository demonstrates how to embed DSM diagnostic criteria using the Mental‑RoBERTa model and visualize the resulting embeddings with UMAP.
+
+## Requirements
+
+Install the Python dependencies:
+
+```bash
+pip install -r Backend/requirements.txt
+```
+
+## Usage
+
+Place a CSV file containing DSM criteria in the following format:
+
+| disorder_name | criteria_text |
+|---------------|---------------|
+| Example Disorder | List of symptom criteria ... |
+
+Run the clustering script:
+
+```bash
+python Backend/cluster_dsm.py path/to/dsm5_criteria.csv --output plot.png
+```
+
+This will generate a scatter plot of the disorders in `plot.png`. If `--output` is omitted, the plot is displayed interactively.
+
+The `--text-column` and `--label-column` options can be used if your CSV uses different column names.


### PR DESCRIPTION
## Summary
- implement `cluster_dsm.py` to embed DSM text with Mental-RoBERTa and visualize with UMAP
- document usage in the README
- add minimal requirements list

## Testing
- `python -m py_compile Backend/cluster_dsm.py`


------
https://chatgpt.com/codex/tasks/task_e_6866943e06d48330b90a84fd06a93e77